### PR TITLE
fixed MITM (http -> https)

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -1,7 +1,7 @@
 var fs = require('fs');
 var path = require('path');
 
-var download_url = 'http://www.angusj.com/resourcehacker/resource_hacker.zip';
+var download_url = 'https://www.angusj.com/resourcehacker/resource_hacker.zip';
 var dir_path = path.join(__dirname,'../bin/');
 var zip_path = path.join(__dirname,'../bin/resource_hacker.zip');
 var bin_path = path.join(__dirname,'../bin/ResourceHacker.exe');
@@ -14,13 +14,13 @@ if(fs.existsSync(bin_path)) {
 	return;
 }
 
-var http = require('http');
-http.globalAgent = require("caw")(process.env.npm_config_proxy || process.env.http_proxy || process.env.HTTP_PROXY);
+var https = require('https');
+https.globalAgent = require("caw")(process.env.npm_config_proxy || process.env.https_proxy || process.env.HTTPS_PROXY);
 var AdmZip = require('adm-zip');
 
 console.log('Downloading ResourceHacker by Angus Johnson...')
 var file = fs.createWriteStream(zip_path);
-var request = http.get(download_url, function(response) {
+var request = https.get(download_url, function(response) {
 	response.pipe(file);
 	file.on('finish', function() {
 		file.close(function(err){

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -1,7 +1,7 @@
 var fs = require('fs');
 var path = require('path');
 
-var download_url = 'https://www.angusj.com/resourcehacker/resource_hacker.zip';
+var download_url = 'http://www.angusj.com/resourcehacker/resource_hacker.zip';
 var dir_path = path.join(__dirname,'../bin/');
 var zip_path = path.join(__dirname,'../bin/resource_hacker.zip');
 var bin_path = path.join(__dirname,'../bin/ResourceHacker.exe');


### PR DESCRIPTION
### 📊 Metadata *

Fixed Resources Downloaded over Insecure Protocol (MiTM)

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-node-resourcehacker/

### ⚙️ Description *

`resourcehacker` is a Node wrapper of Resource Hacker (windows executable resource editor), this package is vulnerable to Man in the Middle (MitM) attacks due to downloading resources over an insecure protocol.
Without a secure connection, it is possible for an attacker to intercept this connection and alter the packages received. In serious cases, this may even lead to Remote Code Execution (RCE) on your host server.

### 💻 Technical Description *

The fix just simply changes the `http` version to `https` to mitigate MITM attacks.

### 🐛 Proof of Concept (PoC) *

The package used `http` in order to access files over the network, the fix changes it to use https instead to as make a secure connection.

### 🔥 Proof of Fix (PoF) *

After the fix, it uses `https` over `http` connection and the problem is mitigated.

### 👍 User Acceptance Testing (UAT)

No breaking changes are introduced.